### PR TITLE
Skip notes on us_cia_world_leaders country pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.sqlite3
 .env
 .vscode
+.idea/
 balkhashdb
 
 # C extensions
@@ -14,6 +15,7 @@ balkhashdb
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/opensanctions/crawlers/us_cia_world_leaders.py
+++ b/opensanctions/crawlers/us_cia_world_leaders.py
@@ -38,12 +38,15 @@ def crawl_country(context, path, country):
     content = blocks.get("free_form_content", []).get("content")
     doc = html.fromstring(content)
     function = None
-    for el in doc.getchildren():
+    for i, el in enumerate(doc.getchildren()):
         text = el.text_content().strip()
         if el.tag == "h2":
             continue
         if el.tag == "h3":
             function = text
+            continue
+        if i == 0 and el.tag == "p":
+            # this paragraph at the start is a note, not a person
             continue
         name = text.replace("(Acting)", "")
         person = emitter.make("Person")


### PR DESCRIPTION
On an us_cia_world_leaders country page, people names are contained in `<p>` elements. However, some of these country pages, for example https://www.cia.gov/resources/government/vietnam/, also contain notes in `<p>` elements. These notes are the first element in the "content" key of "free_form_content", without any preceding headings.

The change simply adds another condition on which to skip the text inside.